### PR TITLE
build: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/example-crs-webservice/litellm/index.yaml
+++ b/example-crs-webservice/litellm/index.yaml
@@ -25,7 +25,7 @@ entries:
       category: Database
       images: |
         - name: os-shell
-          image: docker.io/bitnami/os-shell:12-debian-12-r16
+          image: docker.io/soldevelo/os-shell:12-debian-12-r3
         - name: postgres-exporter
           image: docker.io/bitnami/postgres-exporter:0.15.0-debian-12-r14
         - name: postgresql
@@ -69,7 +69,7 @@ entries:
         - name: kubectl
           image: docker.io/bitnami/kubectl:1.29.2-debian-12-r3
         - name: os-shell
-          image: docker.io/bitnami/os-shell:12-debian-12-r16
+          image: docker.io/soldevelo/os-shell:12-debian-12-r3
         - name: redis
           image: docker.io/bitnami/redis:7.2.4-debian-12-r9
         - name: redis-exporter


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/os-shell:12-debian-12-r16` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)